### PR TITLE
Remove duplicate content-type header + add test gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development do
   gem 'rake'
+  gem 'test-unit'
 end

--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -169,7 +169,7 @@ module Rack
             }.merge!(additional_headers), []]
         when :send_data
           [status, {
-            'Content-Type' => interpreted_to.bytesize,
+            'Content-Length' => interpreted_to.bytesize,
             'Content-Type' => 'text/html',
           }.merge!(additional_headers), [interpreted_to]]
         else


### PR DESCRIPTION
Upon upgrading to ruby-2.2.2 this calls out the duplicate header.

Changed to refer the inferred size to the Length header, and added the test-unit gem to allow `rake` to pass locally
